### PR TITLE
fix(user): remove chamada de rota privada ao fazer logout

### DIFF
--- a/frontend/src/context/user.tsx
+++ b/frontend/src/context/user.tsx
@@ -54,28 +54,30 @@ export const UserProvider = ({ children }: UserProps) => {
   const getUsers = async (params: GetUserParams) => {
     setLoadingUserList(true);
 
-    userApi
-      .getUsers(params)
-      .then((response) => {
-        setUserList(response);
-      })
-      .catch((err) => {
-        setUserList([]);
+    if(user){
+      userApi
+        .getUsers(params)
+        .then((response) => {
+          setUserList(response);
+        })
+        .catch((err) => {
+          setUserList([]);
 
-        showAlert({
-          icon: "error",
-          title: "Erro ao listar usuários",
-          text:
-            err.response?.data?.message?.message ||
-            err.response?.data?.message ||
-            "Ocorreu um erro durante a busca.",
-          confirmButtonText: "Retornar",
+          showAlert({
+            icon: "error",
+            title: "Erro ao listar usuários",
+            text:
+              err.response?.data?.message?.message ||
+              err.response?.data?.message ||
+              "Ocorreu um erro durante a busca.",
+            confirmButtonText: "Retornar",
+          });
+        })
+        .finally(() => {
+          setLoadingUserList(false);
         });
-      })
-      .finally(() => {
-        setLoadingUserList(false);
-      });
-  };
+    };
+    }
 
   const registerUser = async (body: RegisterUserParams) => {
     setLoadingCreateUser(true);


### PR DESCRIPTION
Estava testando o cadastro de apresentações com um usuário do tipo:
- `DoctoralStudent` e nível de permissão `Default`
Sempre quando um usuário desse tipo específico entra na parte Minhas apresentações e dps faz logout aparece esse erro. 
O problema era que o componente um dos componentes principais fazia uma chamada no Context de user, que era uma rota privada, ao fazer logout e gerava esse erro pois não existia mais user registrado na aplicação.
![WhatsApp Image 2025-06-25 at 17 45 15](https://github.com/user-attachments/assets/2cc9e27d-ffb3-42ba-94cb-d9a546df6540)

A solução foi simplesmente inserir uma verificação de existência de usuário ao fazer essa chamada, assim essa requisição só é chamada se existir um usuário salva autenticado na aplicação
