### PR TITLE
MFLP-45 fix(FormEdicao): Data refletida de forma errada na edição de evento

### DIFF
--- a/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
+++ b/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
@@ -256,7 +256,7 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
       endDate: final,
       partnersText: "",
     } as EdicaoParams;
-
+    console.log(edicaoData, body)
     if (edicaoData?.id) {
       updateEdicao(edicaoData?.id, body);
       setTimeout(() => {
@@ -338,11 +338,11 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
                 id="ed-inicio-data"
                 onChange={(date) =>
                   field.onChange(
-                    dayjs(date).subtract(1, "day").toISOString() || null
+                    dayjs(date).toISOString() || null
                   )
                 }
                 selected={
-                  field.value ? dayjs(field.value).add(1, "day").toDate() : null
+                  field.value ? dayjs(field.value).toDate() : null
                 }
                 showIcon
                 className="form-control datepicker"


### PR DESCRIPTION
Data de início do evento na tela incial sempre 1 dia a menos do que o settado pelo Superadmin em Editar Evento